### PR TITLE
Adding cmake as a setup requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ The tricubic interpolation scheme is described in:
 
 Installing pytricubic only requires CMake being installed and typing:  
 
+```
 pip install tricubic
+```
 
 A manual build process is not necessary if you just want to use library.
 
@@ -27,12 +29,14 @@ subfolder. Threfore, no external requirements exist.
 
 Installing pytricubic is as easy as:  
 
-  git clone git://github.com/danielguterding/pytricubic.git  
-  cd pytricubic  
-  mkdir build  
-  cd build  
-  cmake ../  
-  make  
+```
+git clone git://github.com/danielguterding/pytricubic.git  
+cd pytricubic  
+mkdir build  
+cd build  
+cmake ../  
+make  
+```
 
 ## 1. Usage
 

--- a/setup.py
+++ b/setup.py
@@ -89,10 +89,16 @@ class CatchTestCommand(TestCommand):
 setup(
     # Information
     name = "tricubic",
-    version = "1.0.2",
+    version = "1.0.3",
     url = "https://github.com/danielguterding/pytricubic",
     author = "Daniel Guterding",
     author_email = "daniel.guterding@gmail.com",
+    long_description=open("./README.md", 'r').read(),
+    long_description_content_type="text/markdown",
+    setup_requires=[
+        'cmake',
+        'setuptools>=18.0',
+    ],
     license = "MIT",
     keywords = "tricubic cubic interpolation",
     # add extension module

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,6 @@ setup(
     long_description_content_type="text/markdown",
     setup_requires=[
         'cmake',
-        'setuptools>=18.0',
     ],
     license = "MIT",
     keywords = "tricubic cubic interpolation",


### PR DESCRIPTION
Hi, i'm using this package in a project I'm working on which uses poetry. The latest version of poetry struggles to install pytricubic because it doesn't have cmake as one of the requirements for setup. I've added it here to setup.py and it is working for me. I've also done some minor edits so that the readme is given as the long description in the setup and it displays code better in the readme.